### PR TITLE
Embed get api key contents into crate docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v2
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:
@@ -82,6 +83,9 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: "${{matrix.os}}-${{matrix.target}}"
 
       - name: Native Test
         uses: actions-rs/cargo@v1

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,9 +1,9 @@
 //!
+//! ## Get An API Key
 //!
-//!
-//! # First Obtain An API Key
-//!
-//! To get an API key, see <a href="#getting-an-openweathermap-api-key">Getting An OpenWeatherMap API Key</a>.
+//! To obtain an API key, go to [https://openweathermap.org/home/sign_in](https://openweathermap.org/home/sign_in) to
+//! sign in or create an account. Once logged in, select your user name from the top-right menu bar and then
+//! **My API Keys**. Use the **Create key** form to create a new key.
 //!
 //! ## Example #1
 //!
@@ -16,8 +16,7 @@
 //! ```rust
 #![doc = include_str!("../examples/get_multiple_readings.rs")]
 //! ```
-//!
-#![doc = include_str!("../../get_api_key.md")]
+
 #![deny(clippy::all, clippy::missing_panics_doc)]
 #![warn(
     rustdoc::broken_intra_doc_links,

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -26,7 +26,9 @@
 //!
 //! ## Get An API Key
 //!
-//! To obtain an OpenWeatherMap API Key, see [this section](#getting-an-openweathermap-api-key).
+//! To obtain an API key, go to [https://openweathermap.org/home/sign_in](https://openweathermap.org/home/sign_in) to
+//! sign in or create an account. Once logged in, select your user name from the top-right menu bar and then
+//! **My API Keys**. Use the **Create key** form to create a new key.
 //!
 //! ## Create A Config File
 //!
@@ -67,8 +69,6 @@
 //!
 //! `openweathermap_exporter` metrics all include the unit of the measurement in their name and HELP text. If you change the setting for `owm.units` in your config file, the names of the metrics and their HELP text will change accordingly.
 //!
-//!
-#![doc = include_str!("../../get_api_key.md")]
 
 mod config;
 mod error;

--- a/get_api_key.md
+++ b/get_api_key.md
@@ -1,3 +1,0 @@
-## Getting An OpenWeatherMap API Key
-
-To obtain an API key, go to [https://openweathermap.org/home/sign_in](https://openweathermap.org/home/sign_in) to sign in or create an account. Once logged in, select your user name from the top-right menu bar and then **My API Keys**. Use the **Create key** form to create a new key.


### PR DESCRIPTION
Embed get api key contents into crate docs because include_str! fails to pull in files at workspace root from withing cargo publish.