### PR TITLE
Wait for longer for integration test to succeed.

### DIFF
--- a/exporter/tests/exporter_integration_test.rs
+++ b/exporter/tests/exporter_integration_test.rs
@@ -37,7 +37,7 @@ async fn exporter_integration_test() -> Result<(), Box<dyn Error>> {
         .parse::<Uri>()
         .unwrap_or_else(|e| panic!("Error parsing URI: {:?}", e));
 
-    let attempts = 3;
+    let attempts = 20;
     for remaining in (0..attempts).rev() {
         let (status, body) = read_from(uri.clone()).await;
 


### PR DESCRIPTION
Some builds were failing the integration test without having loaded the paris query results.  This was spurious.  I suspect the test just needs to wait a little longer before giving up.